### PR TITLE
✨auth/logout 및 auth/me 페이지 생성

### DIFF
--- a/apps/web/src/app/auth/logout/page.tsx
+++ b/apps/web/src/app/auth/logout/page.tsx
@@ -1,0 +1,9 @@
+// @/app/auth/logout/page.tsx
+
+"use client"
+
+import { signOut } from "next-auth/react";
+
+export default function LogoutPage() {
+    signOut({callbackUrl: "/" });
+}

--- a/apps/web/src/app/auth/logout/page.tsx
+++ b/apps/web/src/app/auth/logout/page.tsx
@@ -1,9 +1,9 @@
 // @/app/auth/logout/page.tsx
 
-"use client"
+"use client";
 
 import { signOut } from "next-auth/react";
 
 export default function LogoutPage() {
-    signOut({callbackUrl: "/" });
+  signOut({ callbackUrl: "/" });
 }

--- a/apps/web/src/app/auth/me/page.tsx
+++ b/apps/web/src/app/auth/me/page.tsx
@@ -27,93 +27,59 @@ async function getCurrentUser(userId: bigint) {
   });
 }
 
+export default async function Page() {
+  const session = await getServerSession(authOptions);
 
-export default async function Page(){
+  if (!session) redirect("/auth/login");
 
-    const session = await getServerSession(authOptions);
+  const userId = BigInt(session.user.id);
 
-    if(!session) redirect("/auth/login");
+  const user = await getCurrentUser(userId);
+  if (!user) return <div>존재하지 않는 유저 세션입니다.</div>;
 
-    const userId = BigInt(session.user.id);
+  return (
+    <main>
+      <header></header>
 
-    const user = await getCurrentUser(userId);
-    if(!user) return <div>존재하지 않는 유저 세션입니다.</div>
+      <section>
+        <div>
+          <strong>Name:</strong> <span>{user.displayName}</span>
+        </div>
+        <div>
+          <strong>Role:</strong> <span>{user.role}</span>
+        </div>
+        <div>
+          <strong>Primary Email:</strong> <span>{user.primaryEmail ?? "No email"}</span>
+        </div>
+        <div>
+          <strong>Created:</strong> <span>{user.createdAt.toDateString()}</span>
+        </div>
+        <div>
+          <strong>PI:</strong> <span>{user.pi ? "Linked" : "Not linked"}</span>
+        </div>
+      </section>
 
-    return (
-        <main>
-            <header>
-            </header>
+      <section>
+        <header>
+          <h3>PI info</h3>
+        </header>
 
-            <section>
-                <div>
-                    <strong>Name:</strong> <span>{user.displayName}</span>
-                </div>
-                <div>
-                    <strong>Role:</strong> <span>{user.role}</span>
-                </div>
-                <div>
-                    <strong>Primary Email:</strong>{" "}
-                    <span>{user.primaryEmail ?? "No email"}</span>
-                </div>
-                <div>
-                    <strong>Created:</strong>{" "}
-                    <span>{user.createdAt.toDateString()}</span>
-                </div>
-                <div>
-                    <strong>PI:</strong>{" "}
-                    <span>{user.pi ? "Linked" : "Not linked"}</span>
-                </div>
-            </section>
-
-            <section>
-                <header>
-                <h3>Credentials linked ({user.credentials.length})</h3>
-                </header>
-
-                {user.credentials.length === 0 ? (
-                <p>No credentials linked.</p>
-                ) : (
-                <ul>
-                    {user.credentials.map((cred) => (
-                    <li key={cred.id.toString()}>
-                        <p>
-                            <strong>Provider:</strong> <span>{cred.provider}</span>
-                            {cred.isPrimary ? " (Primary)" : ""}
-                        </p>
-                        <p>
-                            <strong>Email:</strong> <span>{cred.email}</span>
-                        </p>
-                        <p>
-                            <strong>Email verified:</strong>{" "}
-                            <span>{cred.emailVerified ? "Yes" : "No"}</span>
-                        </p>
-                    </li>
-                    ))}
-                </ul>
-                )}
-            </section>
-
-            <section>
-                <header>
-                    <h3>PI info</h3>
-                </header>
-
-                {!user.pi ? (
-                    <p>Not PI user.</p>
-                ) : (
-                    <>
-                    <div>
-                        <strong>Name:</strong> <span>{user.pi.name}</span>
-                    </div>
-                    <div>
-                        <strong>Email:</strong> <span>{user.pi.email}</span>
-                    </div>
-                    <div>
-                        <strong>ScholarUrl:</strong> <span>{user.pi.scholarUrl}</span>
-                    </div>
-                    </>
-                )} 
-            </section>
-        </main>
-    )
+        {!user.pi ? (
+          <p>Not PI user.</p>
+        ) : (
+          <>
+            <div>
+              <strong>Name:</strong> <span>{user.pi.name}</span>
+            </div>
+            <div>
+              <strong>Email:</strong> <span>{user.pi.email}</span>
+            </div>
+            <div>
+              <strong>ScholarUrl:</strong> <span>{user.pi.scholarUrl}</span>
+            </div>
+          </>
+        )}
+      </section>
+    </main>
+  );
 }

--- a/apps/web/src/app/auth/me/page.tsx
+++ b/apps/web/src/app/auth/me/page.tsx
@@ -1,0 +1,119 @@
+// @/app/auth/me/page.tsx
+
+import { prisma } from "@labatory/db";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { redirect } from "next/navigation";
+
+async function getCurrentUser(userId: bigint) {
+  return prisma.user.findUnique({
+    where: { id: userId },
+    include: {
+      pi: true,
+      credentials: {
+        select: {
+          id: true,
+          provider: true,
+          providerUserId: true,
+          email: true,
+          emailVerified: true,
+          isPrimary: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+        orderBy: { createdAt: "desc" },
+      },
+    },
+  });
+}
+
+
+export default async function Page(){
+
+    const session = await getServerSession(authOptions);
+
+    if(!session) redirect("/auth/login");
+
+    const userId = BigInt(session.user.id);
+
+    const user = await getCurrentUser(userId);
+    if(!user) return <div>존재하지 않는 유저 세션입니다.</div>
+
+    return (
+        <main>
+            <header>
+            </header>
+
+            <section>
+                <div>
+                    <strong>Name:</strong> <span>{user.displayName}</span>
+                </div>
+                <div>
+                    <strong>Role:</strong> <span>{user.role}</span>
+                </div>
+                <div>
+                    <strong>Primary Email:</strong>{" "}
+                    <span>{user.primaryEmail ?? "No email"}</span>
+                </div>
+                <div>
+                    <strong>Created:</strong>{" "}
+                    <span>{user.createdAt.toDateString()}</span>
+                </div>
+                <div>
+                    <strong>PI:</strong>{" "}
+                    <span>{user.pi ? "Linked" : "Not linked"}</span>
+                </div>
+            </section>
+
+            <section>
+                <header>
+                <h3>Credentials linked ({user.credentials.length})</h3>
+                </header>
+
+                {user.credentials.length === 0 ? (
+                <p>No credentials linked.</p>
+                ) : (
+                <ul>
+                    {user.credentials.map((cred) => (
+                    <li key={cred.id.toString()}>
+                        <p>
+                            <strong>Provider:</strong> <span>{cred.provider}</span>
+                            {cred.isPrimary ? " (Primary)" : ""}
+                        </p>
+                        <p>
+                            <strong>Email:</strong> <span>{cred.email}</span>
+                        </p>
+                        <p>
+                            <strong>Email verified:</strong>{" "}
+                            <span>{cred.emailVerified ? "Yes" : "No"}</span>
+                        </p>
+                    </li>
+                    ))}
+                </ul>
+                )}
+            </section>
+
+            <section>
+                <header>
+                    <h3>PI info</h3>
+                </header>
+
+                {!user.pi ? (
+                    <p>Not PI user.</p>
+                ) : (
+                    <>
+                    <div>
+                        <strong>Name:</strong> <span>{user.pi.name}</span>
+                    </div>
+                    <div>
+                        <strong>Email:</strong> <span>{user.pi.email}</span>
+                    </div>
+                    <div>
+                        <strong>ScholarUrl:</strong> <span>{user.pi.scholarUrl}</span>
+                    </div>
+                    </>
+                )} 
+            </section>
+        </main>
+    )
+}


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?

<!-- Describe the feature or enhancement you implemented -->
- auth/logout과 auth/me 페이지를 추가했습니다.

---

### What Issue does this PR fix?

<!-- MUST write in `fixed #number` form so that GitHub can detect the issue automatically -->
-  fix #27 

---

### Is there any consideration on your implementation?

<!-- If there is some alternatives or considerations on your implementation, please let me know -->
- auth/me 페이지에서는 유저의 이름, 역할, 주 메일 주소, 생성 날짜, 유저와 연결된 PI의 정보를 확인할 수 있게 했습니다.
- credential 정보는 확인할 수 없는게 맞는것 같아 넣지 않았습니다.

---
