### PR TITLE
✨Add View Counter

### DIFF
--- a/apps/web/src/app/api/article/view/route.ts
+++ b/apps/web/src/app/api/article/view/route.ts
@@ -48,10 +48,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid article id." }, { status: 400 });
   }
 
-  const ip = await getClientIp();
-  if (!ip) {
-    return NextResponse.json({ error: "Invalid client ip." }, { status: 400 });
-  }
+  const ip = (await getClientIp()) ?? "unknown";
 
   const session = await getServerSession(authOptions);
   let userId: bigint | null = null;

--- a/apps/web/src/app/api/article/view/route.ts
+++ b/apps/web/src/app/api/article/view/route.ts
@@ -5,7 +5,7 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 
-import { record_view } from "@/repository/db/article/view";
+import { CreateArticleViewLog } from "@/repository/db/article/view";
 import { getClientIp } from "@/util/util";
 
 type Body = {
@@ -64,7 +64,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    await record_view({ articleId, ip, userId });
+    await CreateArticleViewLog({ articleId, ip, userId });
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch {
     return NextResponse.json({ error: "Internal server error." }, { status: 500 });

--- a/apps/web/src/app/api/article/view/route.ts
+++ b/apps/web/src/app/api/article/view/route.ts
@@ -1,0 +1,72 @@
+// @/app/api/article/view/route.ts
+
+import { NextResponse } from "next/server";
+
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+import { record_view } from "@/repository/db/article/view";
+import { getClientIp } from "@/util/util";
+
+type Body = {
+  articleId: string;
+};
+
+/**
+ * Handle article view recording requests.
+ *
+ * This endpoint is called by the client after 3 seconds of viewing an article.
+ * It records the view in the `article_view_log` table.
+ *
+ * - Anonymous users (no session) are also recorded using their IP.
+ * - No authentication is required to record a view.
+ *
+ * @param request - Incoming HTTP request containing a JSON body with `articleId`.
+ *
+ * @returns
+ * - `200` with `{ ok: true }` if the view is recorded
+ * - `400` for validation errors
+ * - `500` for internal or database errors
+ */
+export async function POST(request: Request) {
+  let body: Body;
+  try {
+    body = (await request.json()) as Body;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const rawArticleId = body.articleId?.toString().trim() ?? "";
+  if (!rawArticleId) {
+    return NextResponse.json({ error: "Article id is required." }, { status: 400 });
+  }
+
+  let articleId: bigint;
+  try {
+    articleId = BigInt(rawArticleId);
+  } catch {
+    return NextResponse.json({ error: "Invalid article id." }, { status: 400 });
+  }
+
+  const ip = await getClientIp();
+  if (!ip) {
+    return NextResponse.json({ error: "Invalid client ip." }, { status: 400 });
+  }
+
+  const session = await getServerSession(authOptions);
+  let userId: bigint | null = null;
+  if (session?.user?.id) {
+    try {
+      userId = BigInt(session.user.id);
+    } catch {
+      userId = null;
+    }
+  }
+
+  try {
+    await record_view({ articleId, ip, userId });
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch {
+    return NextResponse.json({ error: "Internal server error." }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/article/[article_id]/ViewCounter.tsx
+++ b/apps/web/src/app/article/[article_id]/ViewCounter.tsx
@@ -1,0 +1,25 @@
+// @/app/article/[article_id]/ViewCounter.tsx
+
+"use client";
+
+import { useEffect } from "react";
+
+type Props = {
+  articleId: string;
+};
+
+export function ViewCounter({ articleId }: Props) {
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      fetch("/api/article/view", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ articleId }),
+      });
+    }, 3000);
+
+    return () => clearTimeout(timeout);
+  }, [articleId]);
+
+  return null;
+}

--- a/apps/web/src/app/article/[article_id]/ViewCounter.tsx
+++ b/apps/web/src/app/article/[article_id]/ViewCounter.tsx
@@ -10,15 +10,20 @@ type Props = {
 
 export function ViewCounter({ articleId }: Props) {
   useEffect(() => {
+    const controller = new AbortController();
     const timeout = setTimeout(() => {
       fetch("/api/article/view", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ articleId }),
-      });
+        signal: controller.signal,
+      }).catch(() => {});
     }, 3000);
 
-    return () => clearTimeout(timeout);
+    return () => {
+      clearTimeout(timeout);
+      controller.abort();
+    };
   }, [articleId]);
 
   return null;

--- a/apps/web/src/app/article/[article_id]/page.tsx
+++ b/apps/web/src/app/article/[article_id]/page.tsx
@@ -12,6 +12,7 @@ import { CommentSection } from "./section/CommentSection";
 import { EmoteSection } from "./section/EmoteSection";
 import { CommentForm } from "./section/CommentForm";
 import { WriterSection } from "./section/WriterSection";
+import { ViewCounter } from "./ViewCounter";
 
 function ParseArticleId(articleIdRaw: string): bigint {
   try {
@@ -47,6 +48,7 @@ export default async function Page({ params }: { params: { article_id: string } 
 
   return (
     <article>
+      <ViewCounter articleId={article.id} />
       <header>
         <div>
           <Link href={`/board/${article.boardId}/list`}>Return to board.</Link>

--- a/apps/web/src/repository/db/article/view.ts
+++ b/apps/web/src/repository/db/article/view.ts
@@ -1,0 +1,26 @@
+// @/repository/db/article/view.ts
+
+"use server";
+
+import { prisma } from "@labatory/db";
+
+/**
+ * Record a new article view log.
+ */
+export async function record_view({
+  articleId,
+  ip,
+  userId,
+}: {
+  articleId: bigint;
+  ip: string;
+  userId: bigint | null;
+}): Promise<void> {
+  await prisma.articleViewLog.create({
+    data: {
+      articleId,
+      ip,
+      userId,
+    },
+  });
+}

--- a/apps/web/src/repository/db/article/view.ts
+++ b/apps/web/src/repository/db/article/view.ts
@@ -1,13 +1,11 @@
 // @/repository/db/article/view.ts
 
-"use server";
-
 import { prisma } from "@labatory/db";
 
 /**
- * Record a new article view log.
+ * Create a new article view log.
  */
-export async function record_view({
+export async function CreateArticleViewLog({
   articleId,
   ip,
   userId,

--- a/apps/web/src/repository/dto/article.ts
+++ b/apps/web/src/repository/dto/article.ts
@@ -94,7 +94,6 @@ export type ArticleDbShape = {
   boardId: bigint;
   title: string;
   content: string;
-  viewCount: number;
   createdAt: Date;
   updatedAt: Date;
 
@@ -103,7 +102,7 @@ export type ArticleDbShape = {
   emotes: PostEmoteDbShape[];
   comments: CommentDbShape[];
 
-  _count: { comments: number };
+  _count: { comments: number; viewLogs: number };
 };
 
 export const getArticleSelect = {
@@ -111,7 +110,6 @@ export const getArticleSelect = {
   boardId: true,
   title: true,
   content: true,
-  viewCount: true,
   tags: {
     select: {
       tag: { select: getTagSelect },
@@ -125,7 +123,7 @@ export const getArticleSelect = {
     orderBy: { createdAt: "asc" as const },
     select: getCommentSelect,
   },
-  _count: { select: { comments: true } },
+  _count: { select: { comments: true, viewLogs: true } },
 } as const;
 
 export type ArticleDTO = {

--- a/apps/web/src/repository/serialize/article.ts
+++ b/apps/web/src/repository/serialize/article.ts
@@ -54,7 +54,7 @@ export function serializeArticle(article: ArticleDbShape): ArticleDTO {
     boardId: article.boardId.toString(),
     title: article.title,
     content: article.content,
-    viewCount: article.viewCount,
+    viewCount: article._count.viewLogs,
     createdAt: article.createdAt.toISOString(),
     updatedAt: article.updatedAt.toISOString(),
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -390,6 +390,8 @@ model ArticleViewLog {
   viewedAt  DateTime @default(now()) @map("viewed_at")
 
   @@index([articleId], map: "idx_article_view_log_article_id")
+  @@index([viewedAt], map: "idx_article_view_log_viewed_at")
+  @@index([userId], map: "idx_article_view_log_user_id")
   @@map("article_view_log")
 }
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -61,6 +61,7 @@ model User {
   reviewReports  LabReviewReport[]
   
   updatedBoard    Board[]
+  articleViewLogs ArticleViewLog[]
   @@map("users")
 }
 
@@ -353,7 +354,6 @@ model Article {
   title     String @db.VarChar(200)
   content   String
   articleHistory ArticleHistory[]
-  viewCount Int    @default(0) @map("view_count")
 
   tags      ArticleTag[]
 
@@ -364,6 +364,7 @@ model Article {
   emotes Emote[]
 
   comments  Comment[]
+  viewLogs  ArticleViewLog[]
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt      @map("updated_at")
@@ -374,6 +375,22 @@ model Article {
 
   @@index([createdAt], map: "idx_articles_created_at")
   @@map("articles")
+}
+
+model ArticleViewLog {
+  id        BigInt   @id @default(autoincrement())
+
+  articleId BigInt   @map("article_id")
+  article   Article  @relation(fields: [articleId], references: [id], onDelete: Cascade)
+
+  userId    BigInt?  @map("user_id")
+  user      User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  ip        String   @db.VarChar(45)
+  viewedAt  DateTime @default(now()) @map("viewed_at")
+
+  @@index([articleId], map: "idx_article_view_log_article_id")
+  @@map("article_view_log")
 }
 
 model ArticleHistory {


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?

<!-- Describe the feature or enhancement you implemented -->
- 게시글 조회수 카운터 기능을 추가하였습니다
    - 유저가 게시물을 3초 이상 열람하면 `POST /api/article/view` 요청을 이용해 기록합니다
    - 로그인 유저는 userID를, 비로그인 유저는 userID=null 을 기록합니다.
    - 데이터베이스의 기존 Article.viewCount는 제거하고, ArticleViewLog 테이블을 추가하였습니다.


---

### What Issue does this PR fix?

<!-- MUST write in `fixed #number` form so that GitHub can detect the issue automatically -->
- Fixed #60 

---

### Is there any consideration on your implementation?

<!-- If there is some alternatives or considerations on your implementation, please let me know -->
- 

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Article view tracking enabled: page visits are recorded automatically after a short read delay via a hidden background tracker.
  * Article pages now include a lightweight view counter that triggers the background view log.

* **Chores**
  * View counts are now derived from per-view logs stored in the database (schema updated to support view logs and related relations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->