### PR TITLE
🐛 Fix getSubjects

### DIFF
--- a/apps/web/src/repository/db/labatory/subject.ts
+++ b/apps/web/src/repository/db/labatory/subject.ts
@@ -35,7 +35,7 @@ export async function getSubjectCore({
 }
 
 /**
- * Retrieve entire subjects data.
+ * Retrieve entire (not deleted) subjects data.
  *
  * This is a DB-only function. No authentication/authorization is performed here.
  *

--- a/apps/web/src/repository/db/labatory/subject.ts
+++ b/apps/web/src/repository/db/labatory/subject.ts
@@ -44,6 +44,9 @@ export async function getSubjectCore({
  */
 export async function getSubjects({ db = prisma }: { db?: DbClient }): Promise<SubjectDTO[]> {
   const subjects = (await db.subject.findMany({
+    where: {
+      isDeleted: false,
+    },
     select: getSubjectSelect,
   })) as SubjectDbShape[];
   return subjects.map(serializeSubject);


### PR DESCRIPTION
<!--
Please follow the gitmoji convention for commit messages.
Common gitmoji examples for quick copy-paste:
✨  :sparkles:  → Introduce new features
📝  :memo:      → Add or update documentation
♻️  :recycle:   → Polish code / Refactor code
⚡  :zap:       → Improve performance / Fix a bug
✅  :white_check_mark: → Add or update tests
🔧  :wrench:   → Add or update configuration files
🔒  :lock:     → Fix security issues
-->

### What feature does this PR add?

<!-- Describe the feature or enhancement you implemented -->
- getSubjects에서 isDeleted가 true인 subjects를 반환받지 않게 하였습니다.
- articleDTO와 마찬가지로 subjectDTO에 isDeleted가 존재하지 않는 고로, isDeleted가 true인 것을 반환받을 경우 거르는 것이 불가능한 상태였습니다.
- 삭제된 subject는 존재하지 않는 subject와 동일시되는게 바람직하다고 하셨으므로, db요청에서부터 걸러야 한다고 생각합니다.

---

### What Issue does this PR fix?

<!-- MUST write in `fixed #number` form so that GitHub can detect the issue automatically -->
- 

---

### Is there any consideration on your implementation?

<!-- If there is some alternatives or considerations on your implementation, please let me know -->
- 

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where soft-deleted subjects were appearing in subject listings and queries. Deleted subjects now correctly excluded from all results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->